### PR TITLE
Bugfix. Fixed extra allocation in iterator

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -24,6 +24,10 @@ func (cdb *CDB) Iter() *Iterator {
 // database or an error. After Next returns false, the Err method will return
 // any error that occurred while iterating.
 func (iter *Iterator) Next() bool {
+	if iter.pos >= iter.endPos {
+		return false
+	}
+
 	keyLength, valueLength, err := readTuple(iter.db.reader, iter.pos)
 	if err != nil {
 		iter.err = err
@@ -42,7 +46,7 @@ func (iter *Iterator) Next() bool {
 	iter.value = buf[keyLength:]
 	iter.pos += 8 + keyLength + valueLength
 
-	return iter.pos <= iter.endPos
+	return true
 }
 
 // Key returns the current key.


### PR DESCRIPTION
Found another bug in the iterator where the Next method would allocate a buffer for the data coming after the last record in the DB. This could potentially be huge depending on what the last call to readTuple returns.

This PR fixes that by checking if we have more records at the start of Next instead of at the end.
