### PR TITLE
Fix reader to be thread-safe by creating a new hasher on each operation

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -15,13 +15,19 @@ func newCDBHash() *cdbHash {
 }
 
 func (h *cdbHash) Write(data []byte) (int, error) {
-	v := h.uint32
+	h.uint32 = CDBHashSum32Update (data, h.uint32)
+	return len(data), nil
+}
+
+func CDBHashSum32(data []byte) (uint32) {
+	return CDBHashSum32Update(data, start)
+}
+
+func CDBHashSum32Update(data []byte, v uint32) (uint32) {
 	for _, b := range data {
 		v = ((v << 5) + v) ^ uint32(b)
 	}
-
-	h.uint32 = v
-	return len(data), nil
+	return v
 }
 
 func (h *cdbHash) Sum(b []byte) []byte {

--- a/writer.go
+++ b/writer.go
@@ -147,7 +147,7 @@ func (cdb *Writer) Freeze() (*CDB, error) {
 	}
 
 	if readerAt, ok := cdb.writer.(io.ReaderAt); ok {
-		return &CDB{reader: readerAt, index: index, hasher: cdb.hasher}, nil
+		return &CDB{reader: readerAt, index: index, hasher: func () (hash.Hash32) { return cdb.hasher }}, nil
 	} else {
 		return nil, os.ErrInvalid
 	}

--- a/writer.go
+++ b/writer.go
@@ -147,7 +147,7 @@ func (cdb *Writer) Freeze() (*CDB, error) {
 	}
 
 	if readerAt, ok := cdb.writer.(io.ReaderAt); ok {
-		return &CDB{reader: readerAt, index: index, hasher: func () (hash.Hash32) { return cdb.hasher }}, nil
+		return &CDB{reader: readerAt, index: index, hasher: adaptHash32(cdb.hasher)}, nil
 	} else {
 		return nil, os.ErrInvalid
 	}


### PR DESCRIPTION
This minor patch allows the user to provide a "hasher builder" with the `NewWithHasher` constructor, that allows the `Reader` to be used in a thread-safe manner.

Without using the `NewWithHasher` (i.e. using the plain `New` function), the behaviour is identical to the current one (i.e. no thread-safety), and thus should retain the performance characteristics (that could be impacted by creating a new hasher on each operation).
