### PR TITLE
Add support for serving the CDB from a `[]byte` array and `Get` methods which work without forcing keys into heap

### DIFF
--- a/cdb.go
+++ b/cdb.go
@@ -85,6 +85,15 @@ func (cdb *CDB) initialize (hasher func ([]byte) (uint32)) (*CDB, error) {
 // Get returns the value for a given key, or nil if it can't be found.
 func (cdb *CDB) Get(key []byte) ([]byte, error) {
 	hash := cdb.hasher(key)
+	return cdb.GetWithHash(key, hash)
+}
+
+func (cdb *CDB) GetWithCdbHash(key []byte) ([]byte, error) {
+	hash := CDBHashSum32(key)
+	return cdb.GetWithHash(key, hash)
+}
+
+func (cdb *CDB) GetWithHash(key []byte, hash uint32) ([]byte, error) {
 
 	table := cdb.index[hash&0xff]
 	if table.length == 0 {

--- a/hash.go
+++ b/hash.go
@@ -15,13 +15,19 @@ func newCDBHash() *cdbHash {
 }
 
 func (h *cdbHash) Write(data []byte) (int, error) {
-	v := h.uint32
+	h.uint32 = CDBHashSum32Update (data, h.uint32)
+	return len(data), nil
+}
+
+func CDBHashSum32(data []byte) (uint32) {
+	return CDBHashSum32Update(data, start)
+}
+
+func CDBHashSum32Update(data []byte, v uint32) (uint32) {
 	for _, b := range data {
 		v = ((v << 5) + v) ^ uint32(b)
 	}
-
-	h.uint32 = v
-	return len(data), nil
+	return v
 }
 
 func (h *cdbHash) Sum(b []byte) []byte {

--- a/iterator.go
+++ b/iterator.go
@@ -28,14 +28,14 @@ func (iter *Iterator) Next() bool {
 		return false
 	}
 
-	keyLength, valueLength, err := readTuple(iter.db.reader, iter.pos)
+	keyLength, valueLength, err := iter.db.readTuple(iter.pos)
 	if err != nil {
 		iter.err = err
 		return false
 	}
 
-	buf := make([]byte, keyLength+valueLength)
-	_, err = iter.db.reader.ReadAt(buf, int64(iter.pos+8))
+	var buf []byte
+	buf, err = iter.db.readAt(iter.pos+8, keyLength+valueLength)
 	if err != nil {
 		iter.err = err
 		return false

--- a/util.go
+++ b/util.go
@@ -5,9 +5,22 @@ import (
 	"io"
 )
 
-func readTuple(r io.ReaderAt, offset uint32) (uint32, uint32, error) {
-	tuple := make([]byte, 8)
-	_, err := r.ReadAt(tuple, int64(offset))
+func (cdb *CDB) readAt(offset uint32, size uint32) ([]byte, error) {
+	var buf []byte
+	if cdb.readerBytes == nil {
+		buf = make([]byte, size)
+		_, err := cdb.reader.ReadAt(buf, int64 (offset))
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		buf = cdb.readerBytes[offset : offset + size]
+	}
+	return buf, nil
+}
+
+func (cdb *CDB) readTuple(offset uint32) (uint32, uint32, error) {
+	tuple, err := cdb.readAt(offset, 8)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/writer.go
+++ b/writer.go
@@ -147,7 +147,7 @@ func (cdb *Writer) Freeze() (*CDB, error) {
 	}
 
 	if readerAt, ok := cdb.writer.(io.ReaderAt); ok {
-		return &CDB{reader: readerAt, index: index, hasher: cdb.hasher}, nil
+		return &CDB{reader: readerAt, index: index, hasher: func () (hash.Hash32) { return cdb.hasher }}, nil
 	} else {
 		return nil, os.ErrInvalid
 	}

--- a/writer.go
+++ b/writer.go
@@ -147,7 +147,7 @@ func (cdb *Writer) Freeze() (*CDB, error) {
 	}
 
 	if readerAt, ok := cdb.writer.(io.ReaderAt); ok {
-		return &CDB{reader: readerAt, index: index, hasher: func () (hash.Hash32) { return cdb.hasher }}, nil
+		return &CDB{reader: readerAt, index: index, hasher: adaptHash32(cdb.hasher)}, nil
 	} else {
 		return nil, os.ErrInvalid
 	}


### PR DESCRIPTION
As described in #8 the issue of using interfaces (both for `Hash` and `ReaderAt`) is that any operation involving the database would force the keys out in the heap (in case of `Hash`) and would force buffer allocations in case of `ReaderAt`.

The proposed two patches add support for:
* `GetWithHash` and `GetWithCdbHash` which allow the compiler to keep the key buffer on the stack;
* `NewFromBufferWithHasher` which allows the user to pass a `[]byte` array (perhaps from a `mmap`-ed file) from which the `Get` methods return slices, thus removing the need for heap allocations;
